### PR TITLE
Fix for race condition on RegisterFilterProvider in multi-threaded environments

### DIFF
--- a/src/Autofac.Integration.Mvc/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.Mvc/RegistrationExtensions.cs
@@ -43,6 +43,8 @@ namespace Autofac.Integration.Mvc
     /// </summary>
     public static class RegistrationExtensions
     {
+        private static readonly object providerFilterLock = new object();
+
         /// <summary>
         /// Sets the provided registration to act as an <see cref="IActionFilter"/> for the specified controller.
         /// </summary>
@@ -678,9 +680,11 @@ namespace Autofac.Integration.Mvc
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            foreach (var provider in FilterProviders.Providers.OfType<FilterAttributeFilterProvider>().ToArray())
-            {
-                FilterProviders.Providers.Remove(provider);
+            lock (providerFilterLock) {
+                foreach (var provider in FilterProviders.Providers.OfType<FilterAttributeFilterProvider>().ToArray())
+                {
+                    FilterProviders.Providers.Remove(provider);
+                }
             }
 
             builder.RegisterType<AutofacFilterProvider>()

--- a/test/Autofac.Integration.Mvc.Test/RegistrationExtensionsFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/RegistrationExtensionsFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Web.Mvc;
 using System.Web.Mvc.Filters;
 using Autofac.Builder;
@@ -476,6 +477,15 @@ namespace Autofac.Integration.Mvc.Test
             var builder = new ContainerBuilder();
             builder.RegisterFilterProvider();
             builder.RegisterFilterProvider();
+        }
+
+        [Fact]
+        public void RegisterFilterProviderCanSafelyBeCalledInParallel()
+        {
+            FilterProviders.Providers.Add(new FilterAttributeFilterProvider());
+
+            var builder = new ContainerBuilder();
+            Parallel.For(1, 10, c => builder.RegisterFilterProvider());
         }
 
         [Fact]


### PR DESCRIPTION
- Referenced Issue: https://github.com/autofac/Autofac.Mvc/issues/26

> Note: [xUnit has parallel tests disabled in this project](https://github.com/autofac/Autofac.Mvc/blob/develop/test/Autofac.Integration.Mvc.Test/Properties/AssemblyInfo.cs#L7) so this unit test is more for reference as it doesn't exercise the issue