### PR TITLE
Make integration compatible with Autofac 5

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear/>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="Xunit MyGet" value="https://myget.org/F/xunit/api/v3/index.json" />
+    <clear />
+    <add key="Autofac MyGet" value="https://www.myget.org/F/autofac/api/v2" />
+    <add key="NuGet v3" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  package_semantic_version: 4.0.2
-  assembly_semantic_version: 4.0.0
+  package_semantic_version: 5.0.0
+  assembly_semantic_version: 5.0.0
 
 version: $(package_semantic_version).{build}
 

--- a/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
+++ b/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Reference Include="Autofac, Version=5.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autofac.5.0.0-develop-00611\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>

--- a/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
+++ b/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
@@ -46,9 +46,8 @@
     <AssemblyOriginatorKeyFile>..\..\Autofac.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.0.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.4.0.1\lib\net45\Autofac.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Autofac, Version=5.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.5.0.0-develop-00611\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>

--- a/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.nuspec
+++ b/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.nuspec
@@ -14,7 +14,7 @@
     <iconUrl>https://cloud.githubusercontent.com/assets/1156571/13684110/16b8f152-e6bf-11e5-84ae-22c66c6d351a.png</iconUrl>
     <releaseNotes>Release notes are at https://github.com/autofac/Autofac.Mvc/releases</releaseNotes>
     <dependencies>
-      <dependency id="Autofac" version="[4.0.1,5.0.0)" />
+      <dependency id="Autofac" version="[5.0.0,6.0.0)" />
       <dependency id="Microsoft.AspNet.Mvc" version="[5.1.0,6.0.0)" />
     </dependencies>
   </metadata>

--- a/src/Autofac.Integration.Mvc/packages.config
+++ b/src/Autofac.Integration.Mvc/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.0.1" targetFramework="net45" />
+  <package id="Autofac" version="5.0.0-develop-00611" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.0" targetFramework="net45" />

--- a/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Reference Include="Autofac, Version=5.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Autofac.5.0.0-develop-00611\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>

--- a/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
@@ -45,9 +45,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=4.0.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.4.0.1\lib\net45\Autofac.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Autofac, Version=5.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Autofac.5.0.0-develop-00611\lib\net45\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>

--- a/test/Autofac.Integration.Mvc.Test/packages.config
+++ b/test/Autofac.Integration.Mvc.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="4.0.1" targetFramework="net45" />
+  <package id="Autofac" version="5.0.0-develop-00611" targetFramework="net45" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.1.0" targetFramework="net45" />


### PR DESCRIPTION
As discussed with @alexmg in #28, I've made the suggested workaround for the absence of a ResolveRequest by changing to a loop over the registered services in the one place that it is an issue.

NuSpec dependency changed to [5.0.0, 6.0.0).

Referenced Autofac version will need updating before release.

Fixes #28 