### PR TITLE
Autofac v5 Upgrade

### DIFF
--- a/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
+++ b/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Integration.Mvc</RootNamespace>
     <AssemblyName>Autofac.Integration.Mvc</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -47,8 +47,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=5.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.5.0.0-develop-00611\lib\net45\Autofac.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Autofac.5.0.0\lib\net461\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
@@ -57,6 +59,12 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Autofac.Integration.Mvc/AutofacDependencyResolverResources.Designer.cs
+++ b/src/Autofac.Integration.Mvc/AutofacDependencyResolverResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Autofac.Integration.Mvc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class AutofacDependencyResolverResources {

--- a/src/Autofac.Integration.Mvc/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.Mvc/RegistrationExtensions.cs
@@ -448,7 +448,7 @@ namespace Autofac.Integration.Mvc
                 {
                   foreach (var service in services)
                   {
-                    e.ComponentRegistry.Register(RegistrationBuilder
+                    e.ComponentRegistryBuilder.Register(RegistrationBuilder
                         .ForDelegate((c, p) =>
                         {
                           var session = HttpContext.Current.Session;

--- a/src/Autofac.Integration.Mvc/RegistrationExtensionsResources.Designer.cs
+++ b/src/Autofac.Integration.Mvc/RegistrationExtensionsResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Autofac.Integration.Mvc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class RegistrationExtensionsResources {

--- a/src/Autofac.Integration.Mvc/RequestLifetimeScopeProviderResources.Designer.cs
+++ b/src/Autofac.Integration.Mvc/RequestLifetimeScopeProviderResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Autofac.Integration.Mvc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class RequestLifetimeScopeProviderResources {

--- a/src/Autofac.Integration.Mvc/packages.config
+++ b/src/Autofac.Integration.Mvc/packages.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="5.0.0-develop-00611" targetFramework="net45" />
+  <package id="Autofac" version="5.0.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net461" />
 </packages>

--- a/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Integration.Mvc.Test</RootNamespace>
     <AssemblyName>Autofac.Integration.Mvc.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -46,12 +46,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Autofac, Version=5.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Autofac.5.0.0-develop-00611\lib\net45\Autofac.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Autofac.5.0.0\lib\net461\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
@@ -62,7 +64,14 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/test/Autofac.Integration.Mvc.Test/packages.config
+++ b/test/Autofac.Integration.Mvc.Test/packages.config
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="5.0.0-develop-00611" targetFramework="net45" />
+  <package id="Autofac" version="5.0.0" targetFramework="net461" />
   <package id="Castle.Core" version="3.3.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Moq" version="4.5.19" targetFramework="net451" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net461" />
   <package id="xunit" version="2.1.0" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net451" />


### PR DESCRIPTION
Autofac v5 Compatibility Upgrade.

NuGet package version is still valid from the previous compatibility PR.

Target version changed to 4.6.1