### PR TITLE
Convert from Moq to NSubstitute

### DIFF
--- a/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
+
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.1.0" />

--- a/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <Using Include="System.Web.Mvc" />
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>
 
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.Mvc.Test/AutofacDependencyResolverFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/AutofacDependencyResolverFixture.cs
@@ -124,7 +124,7 @@ public class AutofacDependencyResolverFixture : IClassFixture<DependencyResolver
         Assert.Equal("configurationAction", exception.ParamName);
 
         exception = Assert.Throws<ArgumentNullException>(
-            () => new AutofacDependencyResolver(container, new Mock<ILifetimeScopeProvider>().Object, null));
+            () => new AutofacDependencyResolver(container, Substitute.For<ILifetimeScopeProvider>(), null));
         Assert.Equal("configurationAction", exception.ParamName);
     }
 
@@ -140,11 +140,11 @@ public class AutofacDependencyResolverFixture : IClassFixture<DependencyResolver
         Assert.Equal("container", exception.ParamName);
 
         exception = Assert.Throws<ArgumentNullException>(
-            () => new AutofacDependencyResolver(null, new Mock<ILifetimeScopeProvider>().Object));
+            () => new AutofacDependencyResolver(null, Substitute.For<ILifetimeScopeProvider>()));
         Assert.Equal("container", exception.ParamName);
 
         exception = Assert.Throws<ArgumentNullException>(
-            () => new AutofacDependencyResolver(null, new Mock<ILifetimeScopeProvider>().Object, cb => { }));
+            () => new AutofacDependencyResolver(null, Substitute.For<ILifetimeScopeProvider>(), cb => { }));
         Assert.Equal("container", exception.ParamName);
     }
 

--- a/test/Autofac.Integration.Mvc.Test/AutofacFilterProviderFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/AutofacFilterProviderFixture.cs
@@ -24,7 +24,7 @@ public class AutofacFilterProviderFixture : IClassFixture<DependencyResolverRepl
         this._baseControllerContext = new ControllerContext { Controller = new TestController() };
         this._baseMethodInfo = TestController.GetAction1MethodInfo<TestController>();
         this._actionName = this._baseMethodInfo.Name;
-        this._controllerDescriptor = new Mock<ControllerDescriptor>().Object;
+        this._controllerDescriptor = Substitute.For<ControllerDescriptor>();
         this._reflectedActionDescriptor = new ReflectedActionDescriptor(this._baseMethodInfo, this._actionName, this._controllerDescriptor);
     }
 

--- a/test/Autofac.Integration.Mvc.Test/AutofacFilterTestContext.cs
+++ b/test/Autofac.Integration.Mvc.Test/AutofacFilterTestContext.cs
@@ -18,7 +18,7 @@ namespace Autofac.Integration.Mvc.Test
             this.DerivedMethodInfo = TestController.GetAction1MethodInfo<TestControllerA>();
             this.MostDerivedMethodInfo = TestController.GetAction1MethodInfo<TestControllerB>();
             this.ActionName = this.BaseMethodInfo.Name;
-            this.ControllerDescriptor = new Mock<ControllerDescriptor>().Object;
+            this.ControllerDescriptor = Substitute.For<ControllerDescriptor>();
             this.ReflectedActionDescriptor = new ReflectedActionDescriptor(this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
             this.ReflectedAsyncActionDescriptor = new ReflectedAsyncActionDescriptor(this.BaseMethodInfo, this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
             this.TaskAsyncActionDescriptor = new TaskAsyncActionDescriptor(this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);

--- a/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerPropertyTestContext.cs
+++ b/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerPropertyTestContext.cs
@@ -24,11 +24,11 @@ public class ExtensibleActionInvokerPropertyTestContext : DependencyResolverRepl
 
         DependencyResolver.SetResolver(new AutofacDependencyResolver(this.Container, new StubLifetimeScopeProvider(this.Container)));
 
-        var request = new Mock<HttpRequestBase>();
-        var httpContext = new Mock<HttpContextBase>();
-        httpContext.Setup(mock => mock.Request).Returns(request.Object);
+        var request = Substitute.For<HttpRequestBase>();
+        var httpContext = Substitute.For<HttpContextBase>();
+        httpContext.Request.Returns(request);
         this.Controller = new TestController { ValidateRequest = false };
-        this.ControllerContext = new ControllerContext { Controller = this.Controller, HttpContext = httpContext.Object };
+        this.ControllerContext = new ControllerContext { Controller = this.Controller, HttpContext = httpContext };
         this.Controller.ControllerContext = this.ControllerContext;
         this.Controller.ValueProvider = new NameValueCollectionValueProvider(new NameValueCollection(), CultureInfo.InvariantCulture);
     }

--- a/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerTestContext.cs
+++ b/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerTestContext.cs
@@ -18,11 +18,11 @@ public class ExtensibleActionInvokerTestContext : DependencyResolverReplacementC
 
         DependencyResolver.SetResolver(new AutofacDependencyResolver(this.Container, new StubLifetimeScopeProvider(this.Container)));
 
-        var request = new Mock<HttpRequestBase>();
-        var httpContext = new Mock<HttpContextBase>();
-        httpContext.Setup(mock => mock.Request).Returns(request.Object);
+        var request = Substitute.For<HttpRequestBase>();
+        var httpContext = Substitute.For<HttpContextBase>();
+        httpContext.Request.Returns(request);
         this.Controller = new TestController { ValidateRequest = false };
-        this.ControllerContext = new ControllerContext { Controller = this.Controller, HttpContext = httpContext.Object };
+        this.ControllerContext = new ControllerContext { Controller = this.Controller, HttpContext = httpContext };
         this.Controller.ControllerContext = this.ControllerContext;
         this.Controller.ValueProvider = new NameValueCollectionValueProvider(new NameValueCollection(), CultureInfo.InvariantCulture);
     }

--- a/test/Autofac.Integration.Mvc.Test/RequestLifetimeHttpModuleFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/RequestLifetimeHttpModuleFixture.cs
@@ -15,8 +15,8 @@ public class RequestLifetimeHttpModuleFixture
     [Fact]
     public void CanSetNonNullLifetimeScopeProvider()
     {
-        var provider = new Mock<ILifetimeScopeProvider>();
-        RequestLifetimeHttpModule.SetLifetimeScopeProvider(provider.Object);
-        Assert.Equal(provider.Object, RequestLifetimeHttpModule.LifetimeScopeProvider);
+        var provider = Substitute.For<ILifetimeScopeProvider>();
+        RequestLifetimeHttpModule.SetLifetimeScopeProvider(provider);
+        Assert.Equal(provider, RequestLifetimeHttpModule.LifetimeScopeProvider);
     }
 }


### PR DESCRIPTION
## Summary
- Replace Moq with NSubstitute 5.3.0
- Convert mock patterns across 6 test files
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [ ] CI build passes (net472 project, cannot build locally on macOS)