### PR TITLE
Update target framework to net481

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
-    <Version>6.1.0</Version>
+    <Version>7.0.0</Version>
     <SolutionName>Autofac.Mvc</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
+++ b/src/Autofac.Integration.Mvc/Autofac.Integration.Mvc.csproj
@@ -15,7 +15,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);NU1903</NoWarn>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -57,20 +57,17 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.4.0" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.3.0" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.Web.Infrastructure" Version="2.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
@@ -41,6 +41,7 @@
 
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="Microsoft.AspNet.Razor" Version="3.3.0" />
     <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />

--- a/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
+++ b/test/Autofac.Integration.Mvc.Test/Autofac.Integration.Mvc.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net481</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyTitle>Autofac.Integration.Mvc.Test</AssemblyTitle>
@@ -40,18 +40,17 @@
   <ItemGroup>
 
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0.0" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
+    <PackageReference Include="Microsoft.AspNet.Razor" Version="3.3.0" />
+    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.Web.Infrastructure" Version="2.0.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Update target framework from `net472` to `net481` (.NET Framework 4.8.1)
- Bump version from 6.1.0 to 7.0.0 (breaking change: minimum framework requirement)
- Update Microsoft.AspNet.Mvc to 5.3.0, Microsoft.AspNet.Razor to 3.3.0, Microsoft.AspNet.WebPages to 3.3.0, Microsoft.Web.Infrastructure to 2.0.0
- Replace deprecated Microsoft.CodeAnalysis.Analyzers with Microsoft.CodeAnalysis.NetAnalyzers 9.0.0
- Update Microsoft.SourceLink.GitHub to 8.0.0, StyleCop.Analyzers to 1.2.0-beta.556
- Update test infrastructure: xunit 2.9.3, Microsoft.NET.Test.Sdk 18.0.0, xunit.runner.visualstudio 3.1.5
- Remove unnecessary System.Diagnostics.DiagnosticSource from test project

## Test plan
- [ ] CI build passes
- [ ] All tests pass on net481