### PR TITLE
Standardize build metadata and code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,5 @@
-; EditorConfig to support per-solution formatting.
-; Use the EditorConfig VS add-in to make this work.
-; http://editorconfig.org/
-
-; This is the default for the codeline.
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
 root = true
 
 [*]
@@ -10,13 +7,187 @@ indent_style = space
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-; .NET Code - almost, but not exactly, the same suggestions as corefx
-; https://github.com/dotnet/corefx/blob/master/.editorconfig
+# .NET Code
 [*.cs]
 indent_size = 4
 charset = utf-8-bom
 
-; New line preferences
+# .NET project files and MSBuild - match defaults for VS
+[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
+indent_size = 2
+
+# .NET solution files - match defaults for VS
+[*.sln]
+end_of_line = crlf
+indent_style = tab
+
+# .NET XML solution files - match dotnet new sln defaults
+[*.slnx]
+indent_size = 2
+
+
+# Config - match XML and default nuget.config template
+[*.config]
+indent_size = 2
+
+# Resources - match defaults for VS
+[*.resx]
+indent_size = 2
+
+# Static analysis rulesets - match defaults for VS
+[*.ruleset]
+indent_size = 2
+
+# HTML, XML - match defaults for VS
+[*.{cshtml,html,xml}]
+indent_size = 4
+
+# JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
+[*.{ps1,psd1,psm1}]
+indent_size = 4
+charset = utf-8-bom
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# ReStructuredText - standard indentation format from examples
+[*.rst]
+indent_size = 2
+
+#
+# dotnet code style
+#
+[*.cs]
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# Avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:warning
+dotnet_style_collection_initializer = true:warning
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+
+# Whitespace options
+dotnet_style_allow_multiple_blank_lines_experimental = false
+
+# Non-private static fields are PascalCase
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style = non_private_static_field_style
+
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+
+dotnet_naming_style.non_private_static_field_style.capitalization = pascal_case
+
+# Non-private readonly fields are PascalCase
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_should_be_pascal_case.style = non_private_readonly_field_style
+
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, protected, internal, protected_internal, private_protected
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+
+dotnet_naming_style.non_private_readonly_field_style.capitalization = pascal_case
+
+# Constants are PascalCase
+dotnet_naming_rule.constants_should_be_pascal_case.severity = warning
+dotnet_naming_rule.constants_should_be_pascal_case.symbols = constants
+dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
+
+dotnet_naming_symbols.constants.applicable_kinds = field, local
+dotnet_naming_symbols.constants.required_modifiers = const
+
+dotnet_naming_style.constant_style.capitalization = pascal_case
+
+# Static fields should be _camelCase
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_field_style.capitalization = camel_case
+
+# Instance fields are camelCase and start with _
+dotnet_naming_rule.instance_fields_should_be_camel_case.severity = warning
+dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
+dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+
+dotnet_naming_symbols.instance_fields.applicable_kinds = field
+
+dotnet_naming_style.instance_field_style.capitalization = camel_case
+dotnet_naming_style.instance_field_style.required_prefix = _
+
+# Locals and parameters are camelCase
+dotnet_naming_rule.locals_should_be_camel_case.severity = warning
+dotnet_naming_rule.locals_should_be_camel_case.symbols = locals_and_parameters
+dotnet_naming_rule.locals_should_be_camel_case.style = camel_case_style
+
+dotnet_naming_symbols.locals_and_parameters.applicable_kinds = parameter, local
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# Local functions are PascalCase
+dotnet_naming_rule.local_functions_should_be_pascal_case.severity = warning
+dotnet_naming_rule.local_functions_should_be_pascal_case.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascal_case.style = local_function_style
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+
+dotnet_naming_style.local_function_style.capitalization = pascal_case
+
+# By default, name items with PascalCase
+dotnet_naming_rule.members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.members_should_be_pascal_case.symbols = all_members
+dotnet_naming_rule.members_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.all_members.applicable_kinds = *
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning
+
+# C# code style
+#
+# Newline settings
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -25,90 +196,34 @@ csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
 
-; Indentation preferences
+# Indentation preferences
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = one_less_than_current
+csharp_indent_labels = flush_left
 
-; Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async:warning
+# Whitespace options
+# Each of the *_experimental rules has a corresponding IDE* setting.
+csharp_style_allow_embedded_statements_on_same_line_experimental = false
+dotnet_diagnostic.IDE2001.severity = warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false
+dotnet_diagnostic.IDE2002.severity = warning
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false
+dotnet_diagnostic.IDE2004.severity = warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = false
+dotnet_diagnostic.IDE2005.severity = warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false
+dotnet_diagnostic.IDE2006.severity = warning
 
-; Avoid this. unless absolutely necessary
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
+# Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = warning
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
-; Types: use keywords instead of BCL types, using var is fine.
-csharp_style_var_when_type_is_apparent = false:none
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
-
-; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds   = field
-dotnet_naming_symbols.constant_fields.required_modifiers = const
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-
-; Static fields should be _camelCase
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
-dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
-dotnet_naming_symbols.static_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_fields.required_modifiers = static
-dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
-
-; Static readonly fields should be PascalCase
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
-dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
-dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
-
-; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
-dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
-dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
-dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
-dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
-
-; Code style defaults
-csharp_using_directive_placement = outside_namespace:suggestion
-dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:refactoring
-csharp_preserve_single_line_blocks = true:none
-csharp_preserve_single_line_statements = false:none
-csharp_prefer_static_local_function = true:suggestion
-csharp_prefer_simple_using_statement = false:none
-csharp_style_prefer_switch_expression = true:suggestion
-
-; Code quality
-dotnet_style_readonly_field = true:suggestion
-dotnet_code_quality_unused_parameters = non_public:suggestion
-
-; Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
-dotnet_style_prefer_conditional_expression_over_return = true:refactoring
-csharp_prefer_simple_default_expression = true:suggestion
-
-# Expression-bodied members
+# Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = true:refactoring
 csharp_style_expression_bodied_constructors = true:refactoring
 csharp_style_expression_bodied_operators = true:refactoring
@@ -118,20 +233,15 @@ csharp_style_expression_bodied_accessors = true:refactoring
 csharp_style_expression_bodied_lambdas = true:refactoring
 csharp_style_expression_bodied_local_functions = true:refactoring
 
-# Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-
-# Null checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-
-# Other features
-csharp_style_namespace_declarations = file_scoped:suggestion
-csharp_style_prefer_index_operator = false:none
-csharp_style_prefer_range_operator = false:none
-csharp_style_pattern_local_over_anonymous_function = false:none
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_extended_property_pattern = true:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_parameter_null_checking = false
 
 # Space preferences
 csharp_space_after_cast = false
@@ -157,48 +267,30 @@ csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
 
-; .NET project files and MSBuild - match defaults for VS
-[*.{csproj,nuspec,proj,projitems,props,shproj,targets,vbproj,vcxproj,vcxproj.filters,vsixmanifest,vsct}]
-indent_size = 2
+# Blocks required
+csharp_prefer_braces = true:warning
+csharp_preserve_single_line_blocks = false
+csharp_preserve_single_line_statements = false
 
-; .NET solution files - match defaults for VS
-[*.sln]
-end_of_line = crlf
-indent_style = tab
+# IDE0011: Add braces
+csharp_prefer_braces = when_multiline:warning
+# NOTE: We need the below severity entry for Add Braces due to https://github.com/dotnet/roslyn/issues/44201
+dotnet_diagnostic.IDE0011.severity = warning
 
-; Config - match XML and default nuget.config template
-[*.config]
-indent_size = 2
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
 
-; Resources - match defaults for VS
-[*.resx]
-indent_size = 2
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
 
-; Static analysis rulesets - match defaults for VS
-[*.ruleset]
-indent_size = 2
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
 
-; HTML, XML - match defaults for VS
-[*.{cshtml,html,xml}]
-indent_size = 4
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
 
-; JavaScript and JS mixes - match eslint settings; JSON also matches .NET Core templates
-[*.{js,json,ts,vue}]
-indent_size = 2
+# CA1012: Abstract types should not have public constructors
+dotnet_diagnostic.CA1012.severity = warning
 
-; Markdown - match markdownlint settings
-[*.{md,markdown}]
-indent_size = 2
-
-; PowerShell - match defaults for New-ModuleManifest and PSScriptAnalyzer Invoke-Formatter
-[*.{ps1,psd1,psm1}]
-indent_size = 4
-charset = utf-8-bom
-
-; ReStructuredText - standard indentation format from examples
-[*.rst]
-indent_size = 2
-
-# YAML - match standard YAML like Kubernetes and GitHub Actions
-[*.{yaml,yml}]
-indent_size = 2
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
     hooks:
       - id: check-json
       - id: check-yaml
@@ -8,13 +8,13 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: e72a3ca1632f0b11a07d171449fe447a7ff6795e  # frozen: v0.48.0
+    rev: "e72a3ca1632f0b11a07d171449fe447a7ff6795e"  # frozen: v0.48.0
     hooks:
       - id: markdownlint
         args:
           - --fix
   - repo: https://github.com/tillig/json-sort-cli
-    rev: 2b7e147e0933bd30b58133b6f287e5c695ff4f0e  # frozen: v3.0.1
+    rev: "2b7e147e0933bd30b58133b6f287e5c695ff4f0e"  # frozen: v3.0.1
     hooks:
       - id: json-sort
         args:

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,47 +4,39 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1512" Action="None" />
+    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <Rule Id="CA1513" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
-    <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
-    <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
-    <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
-    <!-- Parameter documentation must be in the right order -->
-    <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
-    <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
-    <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
-    <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- Enable XML documentation output-->
-    <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -2,58 +2,86 @@
 <RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
+    <Rule Id="CA1005" Action="Warning" />
+    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+    <Rule Id="CA1031" Action="None" />
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <Rule Id="CA1040" Action="None" />
+    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <Rule Id="CA1303" Action="None" />
+    <!-- Avoid excessive inheritance (must be explicitly enabled). -->
+    <Rule Id="CA1501" Action="Warning" />
+    <!-- Avoid excessive complexity (must be explicitly enabled). -->
+    <Rule Id="CA1502" Action="Warning" />
+    <!-- Avoid unmaintainable code (must be explicitly enabled). -->
+    <Rule Id="CA1505" Action="Warning" />
+    <!-- Avoid excessive class coupling (must be explicitly enabled). -->
+    <Rule Id="CA1506" Action="Warning" />
+    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <Rule Id="CA1510" Action="None" />
+    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <Rule Id="CA1515" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <Rule Id="CA1707" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
     <Rule Id="CA1816" Action="None" />
     <!-- Mark members static - test methods may not access member data but also can't be static. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <Rule Id="CA1852" Action="None" />
+    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <Rule Id="CA1861" Action="None" />
+    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <Rule Id="CA1863" Action="None" />
+    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
+    <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <Rule Id="CA2263" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
+    <!-- Prefix local calls with this. -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
+    <!-- Use built-in type alias. -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
+    <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
-    <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
+    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
+    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
-    <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
+    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
     <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
-    <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
+    <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
-    <Rule Id="SA1404" Action="None" />
-    <!-- Elements should be documented -->
+    <!-- Elements should be documented. -->
     <Rule Id="SA1600" Action="None" />
-    <!-- Enuemration items should be documented -->
+    <!-- Partial items should be documented. -->
+    <Rule Id="SA1601" Action="None" />
+    <!-- Enumeration items should be documented. -->
     <Rule Id="SA1602" Action="None" />
-    <!-- Parameter documentation must be in the right order -->
+    <!-- Parameter should be documented. -->
+    <Rule Id="SA1611" Action="None" />
+    <!-- Parameter documentation must be in the right order. -->
     <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
+    <!-- Return value must be documented. -->
     <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
+    <!-- Generic type parameters must be documented. -->
     <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
+    <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
-    <Rule Id="SA1627" Action="None" />
-    <!-- Enable XML documentation output-->
-    <Rule Id="SA1652" Action="None" />
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
     <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -9,6 +9,9 @@
         "licenseName": "MIT"
       },
       "xmlHeader": false
+    },
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
     }
   }
 }

--- a/default.proj
+++ b/default.proj
@@ -56,7 +56,8 @@
     <Exec Command="dotnet build &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) /p:Version=$(Version)" />
   </Target>
   <Target Name="Package">
-    <Exec Command="dotnet pack &quot;%(SolutionFile.FullPath)&quot; -c $(Configuration) --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
+    <MakeDir Directories="$(PackageDirectory)" />
+    <Exec Command="dotnet pack &quot;%(SourceProject.Identity)&quot; -c $(Configuration) --no-build --output &quot;$(PackageDirectory)&quot; /p:Version=$(Version)" />
   </Target>
   <Target Name="Test">
     <MakeDir Directories="$(LogDirectory)" />

--- a/src/Autofac.Integration.Mvc/ActionFilterOverride.cs
+++ b/src/Autofac.Integration.Mvc/ActionFilterOverride.cs
@@ -24,7 +24,10 @@ internal class ActionFilterOverride : IActionFilter, IOverrideFilter
     /// <inheritdoc/>
     public Type FiltersToOverride
     {
-        get { return typeof(IActionFilter); }
+        get
+        {
+            return typeof(IActionFilter);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Autofac.Integration.Mvc/AuthenticationFilterOverride.cs
+++ b/src/Autofac.Integration.Mvc/AuthenticationFilterOverride.cs
@@ -24,7 +24,10 @@ internal class AuthenticationFilterOverride : IAuthenticationFilter, IOverrideFi
     /// <inheritdoc/>
     public Type FiltersToOverride
     {
-        get { return typeof(IAuthenticationFilter); }
+        get
+        {
+            return typeof(IAuthenticationFilter);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Autofac.Integration.Mvc/AuthorizationFilterOverride.cs
+++ b/src/Autofac.Integration.Mvc/AuthorizationFilterOverride.cs
@@ -24,7 +24,10 @@ internal class AuthorizationFilterOverride : IAuthorizationFilter, IOverrideFilt
     /// <inheritdoc/>
     public Type FiltersToOverride
     {
-        get { return typeof(IAuthorizationFilter); }
+        get
+        {
+            return typeof(IAuthorizationFilter);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Autofac.Integration.Mvc/AutofacDependencyResolver.cs
+++ b/src/Autofac.Integration.Mvc/AutofacDependencyResolver.cs
@@ -81,7 +81,10 @@ public class AutofacDependencyResolver : IDependencyResolver
     /// </summary>
     public ILifetimeScope ApplicationContainer
     {
-        get { return _container; }
+        get
+        {
+            return _container;
+        }
     }
 
     /// <summary>

--- a/src/Autofac.Integration.Mvc/AutofacFilterProvider.cs
+++ b/src/Autofac.Integration.Mvc/AutofacFilterProvider.cs
@@ -313,12 +313,24 @@ public class AutofacFilterProvider : FilterAttributeFilterProvider
 
     private class FilterContext
     {
-        public ActionDescriptor ActionDescriptor { get; set; }
+        public ActionDescriptor ActionDescriptor
+        {
+            get; set;
+        }
 
-        public Type ControllerType { get; set; }
+        public Type ControllerType
+        {
+            get; set;
+        }
 
-        public List<Filter> Filters { get; set; }
+        public List<Filter> Filters
+        {
+            get; set;
+        }
 
-        public ILifetimeScope LifetimeScope { get; set; }
+        public ILifetimeScope LifetimeScope
+        {
+            get; set;
+        }
     }
 }

--- a/src/Autofac.Integration.Mvc/ExceptionFilterOverride.cs
+++ b/src/Autofac.Integration.Mvc/ExceptionFilterOverride.cs
@@ -24,7 +24,10 @@ internal class ExceptionFilterOverride : IExceptionFilter, IOverrideFilter
     /// <inheritdoc/>
     public Type FiltersToOverride
     {
-        get { return typeof(IExceptionFilter); }
+        get
+        {
+            return typeof(IExceptionFilter);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Autofac.Integration.Mvc/FilterMetadata.cs
+++ b/src/Autofac.Integration.Mvc/FilterMetadata.cs
@@ -15,23 +15,35 @@ internal class FilterMetadata
     /// Gets or sets the type of the controller.
     /// </summary>
     [DefaultValue(null)]
-    public Type ControllerType { get; set; }
+    public Type ControllerType
+    {
+        get; set;
+    }
 
     /// <summary>
     /// Gets or sets the filter scope.
     /// </summary>
     [DefaultValue(FilterScope.First)]
-    public FilterScope FilterScope { get; set; }
+    public FilterScope FilterScope
+    {
+        get; set;
+    }
 
     /// <summary>
     /// Gets or sets the method info.
     /// </summary>
     [DefaultValue(null)]
-    public MethodInfo MethodInfo { get; set; }
+    public MethodInfo MethodInfo
+    {
+        get; set;
+    }
 
     /// <summary>
     /// Gets or sets the order in which the filter is applied.
     /// </summary>
     [DefaultValue(-1)]
-    public int Order { get; set; }
+    public int Order
+    {
+        get; set;
+    }
 }

--- a/src/Autofac.Integration.Mvc/ILifetimeScopeProvider.cs
+++ b/src/Autofac.Integration.Mvc/ILifetimeScopeProvider.cs
@@ -9,22 +9,26 @@ namespace Autofac.Integration.Mvc;
 public interface ILifetimeScopeProvider
 {
     /// <summary>
+    /// Gets the global, application-wide container.
+    /// </summary>
+    ILifetimeScope ApplicationContainer
+    {
+        get;
+    }
+
+    /// <summary>
     /// Gets a nested lifetime scope that services can be resolved from.
     /// </summary>
     /// <param name="configurationAction">
     /// A configuration action that will execute during lifetime scope creation.
     /// </param>
     /// <returns>A new or existing nested lifetime scope.</returns>
-    [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+    [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Method accepts a configuration action parameter.")]
     ILifetimeScope GetLifetimeScope(Action<ContainerBuilder> configurationAction);
 
     /// <summary>
     /// Ends the current lifetime scope.
     /// </summary>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
     ValueTask EndLifetimeScope();
-
-    /// <summary>
-    /// Gets the global, application-wide container.
-    /// </summary>
-    ILifetimeScope ApplicationContainer { get; }
 }

--- a/src/Autofac.Integration.Mvc/ModelBinderTypeAttribute.cs
+++ b/src/Autofac.Integration.Mvc/ModelBinderTypeAttribute.cs
@@ -6,15 +6,10 @@ namespace Autofac.Integration.Mvc;
 /// <summary>
 /// Indicates what types a model binder supports.
 /// </summary>
-[SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments")]
+[SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "Constructor accepts params array but property exposes IEnumerable.")]
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
 public sealed class ModelBinderTypeAttribute : Attribute
 {
-    /// <summary>
-    /// Gets the target types.
-    /// </summary>
-    public IEnumerable<Type> TargetTypes { get; private set; }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ModelBinderTypeAttribute"/> class.
     /// </summary>
@@ -36,5 +31,13 @@ public sealed class ModelBinderTypeAttribute : Attribute
         }
 
         TargetTypes = new Type[] { targetType };
+    }
+
+    /// <summary>
+    /// Gets the target types.
+    /// </summary>
+    public IEnumerable<Type> TargetTypes
+    {
+        get; private set;
     }
 }

--- a/src/Autofac.Integration.Mvc/RegistrationExtensions.cs
+++ b/src/Autofac.Integration.Mvc/RegistrationExtensions.cs
@@ -536,6 +536,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     public static void OverrideActionFilterFor<TController>(this ContainerBuilder builder)
             where TController : IController
@@ -546,6 +547,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller action.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     /// <param name="actionSelector">The action selector.</param>
     public static void OverrideActionFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
@@ -557,6 +559,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     public static void OverrideAuthenticationFilterFor<TController>(this ContainerBuilder builder)
             where TController : IController
@@ -567,6 +570,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller action.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     /// <param name="actionSelector">The action selector.</param>
     public static void OverrideAuthenticationFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
@@ -578,6 +582,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     public static void OverrideAuthorizationFilterFor<TController>(this ContainerBuilder builder)
             where TController : IController
@@ -588,6 +593,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller action.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     /// <param name="actionSelector">The action selector.</param>
     public static void OverrideAuthorizationFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
@@ -599,6 +605,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     public static void OverrideExceptionFilterFor<TController>(this ContainerBuilder builder)
             where TController : IController
@@ -609,6 +616,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller action.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     /// <param name="actionSelector">The action selector.</param>
     public static void OverrideExceptionFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
@@ -620,6 +628,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     public static void OverrideResultFilterFor<TController>(this ContainerBuilder builder)
             where TController : IController
@@ -630,6 +639,7 @@ public static class RegistrationExtensions
     /// <summary>
     /// Sets the provided registration to act as an <see cref="IOverrideFilter"/> for the specified controller action.
     /// </summary>
+    /// <typeparam name="TController">The type of the controller.</typeparam>
     /// <param name="builder">The container builder.</param>
     /// <param name="actionSelector">The action selector.</param>
     public static void OverrideResultFilterFor<TController>(this ContainerBuilder builder, Expression<Action<TController>> actionSelector)
@@ -767,7 +777,7 @@ public static class RegistrationExtensions
 
         if (!limitType.IsAssignableTo<TFilter>())
         {
-            string message = string.Format(
+            var message = string.Format(
                                 CultureInfo.CurrentCulture,
                                 RegistrationExtensionsResources.MustBeAssignableToFilterType,
                                 limitType.FullName,
@@ -804,7 +814,7 @@ public static class RegistrationExtensions
 
         if (!limitType.IsAssignableTo<TFilter>())
         {
-            string message = string.Format(
+            var message = string.Format(
                                 CultureInfo.CurrentCulture,
                                 RegistrationExtensionsResources.MustBeAssignableToFilterType,
                                 limitType.FullName,

--- a/src/Autofac.Integration.Mvc/RequestLifetimeHttpModule.cs
+++ b/src/Autofac.Integration.Mvc/RequestLifetimeHttpModule.cs
@@ -14,7 +14,21 @@ internal class RequestLifetimeHttpModule : IHttpModule
     /// <summary>
     /// Gets the lifetime scope provider that should be notified when a HTTP request ends.
     /// </summary>
-    internal static ILifetimeScopeProvider LifetimeScopeProvider { get; private set; }
+    internal static ILifetimeScopeProvider LifetimeScopeProvider
+    {
+        get; private set;
+    }
+
+    /// <summary>
+    /// Sets the global lifetime scope provider.
+    /// </summary>
+    /// <param name="lifetimeScopeProvider">
+    /// The <see cref="ILifetimeScopeProvider"/> that manages the ambient request lifetime scope.
+    /// </param>
+    public static void SetLifetimeScopeProvider(ILifetimeScopeProvider lifetimeScopeProvider)
+    {
+        LifetimeScopeProvider = lifetimeScopeProvider ?? throw new ArgumentNullException(nameof(lifetimeScopeProvider));
+    }
 
     /// <summary>
     /// Initializes a module and prepares it to handle requests.
@@ -41,17 +55,6 @@ internal class RequestLifetimeHttpModule : IHttpModule
     /// </summary>
     public void Dispose()
     {
-    }
-
-    /// <summary>
-    /// Sets the global lifetime scope provider.
-    /// </summary>
-    /// <param name="lifetimeScopeProvider">
-    /// The <see cref="ILifetimeScopeProvider"/> that manages the ambient request lifetime scope.
-    /// </param>
-    public static void SetLifetimeScopeProvider(ILifetimeScopeProvider lifetimeScopeProvider)
-    {
-        LifetimeScopeProvider = lifetimeScopeProvider ?? throw new ArgumentNullException(nameof(lifetimeScopeProvider));
     }
 
     [SuppressMessage("CA1849", "CA1849", Justification = "If the value task is already completed, getting the result synchronously isn't a problem.")]

--- a/src/Autofac.Integration.Mvc/RequestLifetimeScopeProvider.cs
+++ b/src/Autofac.Integration.Mvc/RequestLifetimeScopeProvider.cs
@@ -32,13 +32,23 @@ public class RequestLifetimeScopeProvider : ILifetimeScopeProvider
     /// </summary>
     public ILifetimeScope ApplicationContainer
     {
-        get { return _container; }
+        get
+        {
+            return _container;
+        }
     }
 
     private static ILifetimeScope LifetimeScope
     {
-        get { return (ILifetimeScope)HttpContext.Current.Items[typeof(ILifetimeScope)]; }
-        set { HttpContext.Current.Items[typeof(ILifetimeScope)] = value; }
+        get
+        {
+            return (ILifetimeScope)HttpContext.Current.Items[typeof(ILifetimeScope)];
+        }
+
+        set
+        {
+            HttpContext.Current.Items[typeof(ILifetimeScope)] = value;
+        }
     }
 
     /// <summary>
@@ -70,6 +80,7 @@ public class RequestLifetimeScopeProvider : ILifetimeScopeProvider
     /// <summary>
     /// Ends the current HTTP request lifetime scope.
     /// </summary>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
     public ValueTask EndLifetimeScope()
     {
         if (HttpContext.Current == null)
@@ -90,7 +101,7 @@ public class RequestLifetimeScopeProvider : ILifetimeScopeProvider
     /// A configuration action that will execute during lifetime scope creation.
     /// </param>
     /// <returns>A new lifetime scope for the current HTTP request.</returns>
-    [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+    [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Method accepts a configuration action parameter.")]
     protected virtual ILifetimeScope GetLifetimeScopeCore(Action<ContainerBuilder> configurationAction)
     {
         return (configurationAction == null)

--- a/src/Autofac.Integration.Mvc/ResultFilterOverride.cs
+++ b/src/Autofac.Integration.Mvc/ResultFilterOverride.cs
@@ -24,7 +24,10 @@ internal class ResultFilterOverride : IResultFilter, IOverrideFilter
     /// <inheritdoc/>
     public Type FiltersToOverride
     {
-        get { return typeof(IResultFilter); }
+        get
+        {
+            return typeof(IResultFilter);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Autofac.Integration.Mvc/ViewRegistrationSource.cs
+++ b/src/Autofac.Integration.Mvc/ViewRegistrationSource.cs
@@ -16,6 +16,18 @@ namespace Autofac.Integration.Mvc;
 public class ViewRegistrationSource : IRegistrationSource
 {
     /// <summary>
+    /// Gets a value indicating whether the registrations provided by this source are 1:1 adapters on top
+    /// of other components (I.e. like Meta, Func or Owned.)
+    /// </summary>
+    public bool IsAdapterForIndividualComponents
+    {
+        get
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Retrieve registrations for an unregistered service, to be used
     /// by the container.
     /// </summary>
@@ -31,15 +43,6 @@ public class ViewRegistrationSource : IRegistrationSource
                 .InstancePerDependency()
                 .CreateRegistration();
         }
-    }
-
-    /// <summary>
-    /// Gets a value indicating whether the registrations provided by this source are 1:1 adapters on top
-    /// of other components (I.e. like Meta, Func or Owned.)
-    /// </summary>
-    public bool IsAdapterForIndividualComponents
-    {
-        get { return false; }
     }
 
     private static bool IsSupportedView(Type serviceType)

--- a/test/Autofac.Integration.Mvc.Test/AutofacFilterBaseFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/AutofacFilterBaseFixture.cs
@@ -14,7 +14,10 @@ public abstract class AutofacFilterBaseFixture<TFilter1, TFilter2, TFilterType> 
         this.TestContext = testContext;
     }
 
-    public AutofacFilterTestContext TestContext { get; private set; }
+    public AutofacFilterTestContext TestContext
+    {
+        get; private set;
+    }
 
     [Fact]
     public void ResolvesActionScopedFilterForImmediateBaseContoller()

--- a/test/Autofac.Integration.Mvc.Test/AutofacFilterTestContext.cs
+++ b/test/Autofac.Integration.Mvc.Test/AutofacFilterTestContext.cs
@@ -5,51 +5,89 @@ using System.Reflection;
 using System.Web.Mvc.Async;
 using Autofac.Integration.Mvc.Test.Stubs;
 
-namespace Autofac.Integration.Mvc.Test
+namespace Autofac.Integration.Mvc.Test;
+
+public class AutofacFilterTestContext
 {
-    public class AutofacFilterTestContext
+    public AutofacFilterTestContext()
     {
-        public AutofacFilterTestContext()
-        {
-            this.BaseControllerContext = new ControllerContext { Controller = new TestController() };
-            this.DerivedControllerContext = new ControllerContext { Controller = new TestControllerA() };
-            this.MostDerivedControllerContext = new ControllerContext { Controller = new TestControllerB() };
-            this.BaseMethodInfo = TestController.GetAction1MethodInfo<TestController>();
-            this.DerivedMethodInfo = TestController.GetAction1MethodInfo<TestControllerA>();
-            this.MostDerivedMethodInfo = TestController.GetAction1MethodInfo<TestControllerB>();
-            this.ActionName = this.BaseMethodInfo.Name;
-            this.ControllerDescriptor = Substitute.For<ControllerDescriptor>();
-            this.ReflectedActionDescriptor = new ReflectedActionDescriptor(this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
-            this.ReflectedAsyncActionDescriptor = new ReflectedAsyncActionDescriptor(this.BaseMethodInfo, this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
-            this.TaskAsyncActionDescriptor = new TaskAsyncActionDescriptor(this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
-            this.DerivedActionDescriptor = new ReflectedActionDescriptor(this.DerivedMethodInfo, this.ActionName, this.ControllerDescriptor);
-            this.MostDerivedActionDescriptor = new ReflectedActionDescriptor(this.MostDerivedMethodInfo, this.ActionName, this.ControllerDescriptor);
-        }
+        this.BaseControllerContext = new ControllerContext { Controller = new TestController() };
+        this.DerivedControllerContext = new ControllerContext { Controller = new TestControllerA() };
+        this.MostDerivedControllerContext = new ControllerContext { Controller = new TestControllerB() };
+        this.BaseMethodInfo = TestController.GetAction1MethodInfo<TestController>();
+        this.DerivedMethodInfo = TestController.GetAction1MethodInfo<TestControllerA>();
+        this.MostDerivedMethodInfo = TestController.GetAction1MethodInfo<TestControllerB>();
+        this.ActionName = this.BaseMethodInfo.Name;
+        this.ControllerDescriptor = Substitute.For<ControllerDescriptor>();
+        this.ReflectedActionDescriptor = new ReflectedActionDescriptor(this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
+        this.ReflectedAsyncActionDescriptor = new ReflectedAsyncActionDescriptor(this.BaseMethodInfo, this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
+        this.TaskAsyncActionDescriptor = new TaskAsyncActionDescriptor(this.BaseMethodInfo, this.ActionName, this.ControllerDescriptor);
+        this.DerivedActionDescriptor = new ReflectedActionDescriptor(this.DerivedMethodInfo, this.ActionName, this.ControllerDescriptor);
+        this.MostDerivedActionDescriptor = new ReflectedActionDescriptor(this.MostDerivedMethodInfo, this.ActionName, this.ControllerDescriptor);
+    }
 
-        public string ActionName { get; private set; }
+    public string ActionName
+    {
+        get; private set;
+    }
 
-        public ControllerContext BaseControllerContext { get; private set; }
+    public ControllerContext BaseControllerContext
+    {
+        get; private set;
+    }
 
-        public MethodInfo BaseMethodInfo { get; private set; }
+    public MethodInfo BaseMethodInfo
+    {
+        get; private set;
+    }
 
-        public ControllerDescriptor ControllerDescriptor { get; private set; }
+    public ControllerDescriptor ControllerDescriptor
+    {
+        get; private set;
+    }
 
-        public ReflectedActionDescriptor DerivedActionDescriptor { get; private set; }
+    public ReflectedActionDescriptor DerivedActionDescriptor
+    {
+        get; private set;
+    }
 
-        public ControllerContext DerivedControllerContext { get; private set; }
+    public ControllerContext DerivedControllerContext
+    {
+        get; private set;
+    }
 
-        public MethodInfo DerivedMethodInfo { get; private set; }
+    public MethodInfo DerivedMethodInfo
+    {
+        get; private set;
+    }
 
-        public ReflectedActionDescriptor MostDerivedActionDescriptor { get; private set; }
+    public ReflectedActionDescriptor MostDerivedActionDescriptor
+    {
+        get; private set;
+    }
 
-        public ControllerContext MostDerivedControllerContext { get; private set; }
+    public ControllerContext MostDerivedControllerContext
+    {
+        get; private set;
+    }
 
-        public MethodInfo MostDerivedMethodInfo { get; private set; }
+    public MethodInfo MostDerivedMethodInfo
+    {
+        get; private set;
+    }
 
-        public ReflectedActionDescriptor ReflectedActionDescriptor { get; private set; }
+    public ReflectedActionDescriptor ReflectedActionDescriptor
+    {
+        get; private set;
+    }
 
-        public ReflectedAsyncActionDescriptor ReflectedAsyncActionDescriptor { get; private set; }
+    public ReflectedAsyncActionDescriptor ReflectedAsyncActionDescriptor
+    {
+        get; private set;
+    }
 
-        public TaskAsyncActionDescriptor TaskAsyncActionDescriptor { get; private set; }
+    public TaskAsyncActionDescriptor TaskAsyncActionDescriptor
+    {
+        get; private set;
     }
 }

--- a/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerFixture.cs
@@ -10,7 +10,10 @@ public class ExtensibleActionInvokerFixture : IClassFixture<ExtensibleActionInvo
         this.TestContext = testContext;
     }
 
-    public ExtensibleActionInvokerTestContext TestContext { get; private set; }
+    public ExtensibleActionInvokerTestContext TestContext
+    {
+        get; private set;
+    }
 
     [Fact]
     public void ActionInjection_DependencyRegistered_ServiceResolved()

--- a/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerPropertyFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerPropertyFixture.cs
@@ -10,7 +10,10 @@ public class ExtensibleActionInvokerPropertyFixture : IClassFixture<ExtensibleAc
         this.TestContext = testContext;
     }
 
-    public ExtensibleActionInvokerPropertyTestContext TestContext { get; private set; }
+    public ExtensibleActionInvokerPropertyTestContext TestContext
+    {
+        get; private set;
+    }
 
     [Fact]
     public void ActionInjection_DependencyRegistered_ServiceResolved()

--- a/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerPropertyTestContext.cs
+++ b/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerPropertyTestContext.cs
@@ -35,18 +35,33 @@ public class ExtensibleActionInvokerPropertyTestContext : DependencyResolverRepl
 
     public interface IActionDependency
     {
-        ActionDependencyProperty Property { get; }
+        ActionDependencyProperty Property
+        {
+            get;
+        }
     }
 
-    public IContainer Container { get; private set; }
+    public IContainer Container
+    {
+        get; private set;
+    }
 
-    public TestController Controller { get; private set; }
+    public TestController Controller
+    {
+        get; private set;
+    }
 
-    public ControllerContext ControllerContext { get; private set; }
+    public ControllerContext ControllerContext
+    {
+        get; private set;
+    }
 
     public class ActionDependency : IActionDependency
     {
-        public ActionDependencyProperty Property { get; set; }
+        public ActionDependencyProperty Property
+        {
+            get; set;
+        }
     }
 
     public class ActionDependencyProperty
@@ -55,7 +70,10 @@ public class ExtensibleActionInvokerPropertyTestContext : DependencyResolverRepl
 
     public class TestController : Controller
     {
-        public IActionDependency Dependency { get; private set; }
+        public IActionDependency Dependency
+        {
+            get; private set;
+        }
 
         public ActionResult Index(IActionDependency dependency)
         {

--- a/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerTestContext.cs
+++ b/test/Autofac.Integration.Mvc.Test/ExtensibleActionInvokerTestContext.cs
@@ -29,18 +29,33 @@ public class ExtensibleActionInvokerTestContext : DependencyResolverReplacementC
 
     public interface IActionDependency
     {
-        ActionDependencyProperty Property { get; }
+        ActionDependencyProperty Property
+        {
+            get;
+        }
     }
 
-    public IContainer Container { get; private set; }
+    public IContainer Container
+    {
+        get; private set;
+    }
 
-    public TestController Controller { get; private set; }
+    public TestController Controller
+    {
+        get; private set;
+    }
 
-    public ControllerContext ControllerContext { get; private set; }
+    public ControllerContext ControllerContext
+    {
+        get; private set;
+    }
 
     public class ActionDependency : IActionDependency
     {
-        public ActionDependencyProperty Property { get; set; }
+        public ActionDependencyProperty Property
+        {
+            get; set;
+        }
     }
 
     public class ActionDependencyProperty
@@ -49,7 +64,10 @@ public class ExtensibleActionInvokerTestContext : DependencyResolverReplacementC
 
     public class TestController : Controller
     {
-        public IActionDependency Dependency { get; private set; }
+        public IActionDependency Dependency
+        {
+            get; private set;
+        }
 
         public ActionResult Index(IActionDependency dependency)
         {

--- a/test/Autofac.Integration.Mvc.Test/StubLifetimeScopeProvider.cs
+++ b/test/Autofac.Integration.Mvc.Test/StubLifetimeScopeProvider.cs
@@ -18,7 +18,10 @@ public class StubLifetimeScopeProvider : ILifetimeScopeProvider
 
     public ILifetimeScope ApplicationContainer
     {
-        get { return this._container; }
+        get
+        {
+            return this._container;
+        }
     }
 
     public ValueTask EndLifetimeScope()

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewMasterPage.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewMasterPage.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractViewMasterPage : ViewMasterPage
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewMasterPageWithModel.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewMasterPageWithModel.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractViewMasterPageWithModel<T> : ViewMasterPage<T>
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewPage.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewPage.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractViewPage : ViewPage
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewPageWithModel.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewPageWithModel.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractViewPageWithModel<T> : ViewPage<T>
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewUserControl.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewUserControl.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractViewUserControl : ViewUserControl
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewUserControlWithModel.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractViewUserControlWithModel.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractViewUserControlWithModel<T> : ViewUserControl<T>
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractWebViewPage.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractWebViewPage.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractWebViewPage : WebViewPage
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/AbstractWebViewPageWithModel.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/AbstractWebViewPageWithModel.cs
@@ -5,5 +5,8 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public abstract class AbstractWebViewPageWithModel<T> : WebViewPage<T>
 {
-    public Dependency Dependency { get; set; }
+    public Dependency Dependency
+    {
+        get; set;
+    }
 }

--- a/test/Autofac.Integration.Mvc.Test/Stubs/ModelBinder.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/ModelBinder.cs
@@ -12,7 +12,10 @@ public class ModelBinder : IModelBinder
         this.Dependency = dependency;
     }
 
-    public Dependency Dependency { get; private set; }
+    public Dependency Dependency
+    {
+        get; private set;
+    }
 
     public object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
     {

--- a/test/Autofac.Integration.Mvc.Test/Stubs/TestController.cs
+++ b/test/Autofac.Integration.Mvc.Test/Stubs/TestController.cs
@@ -7,7 +7,10 @@ namespace Autofac.Integration.Mvc.Test.Stubs;
 
 public class TestController : Controller
 {
-    public object Dependency { get; set; }
+    public object Dependency
+    {
+        get; set;
+    }
 
     public static MethodInfo GetAction1MethodInfo<T>()
         where T : TestController

--- a/test/Autofac.Integration.Mvc.Test/ViewRegistrationSourceFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/ViewRegistrationSourceFixture.cs
@@ -4,156 +4,155 @@
 using Autofac.Core.Lifetime;
 using Autofac.Integration.Mvc.Test.Stubs;
 
-namespace Autofac.Integration.Mvc.Test
+namespace Autofac.Integration.Mvc.Test;
+
+public class ViewRegistrationSourceFixture
 {
-    public class ViewRegistrationSourceFixture
+    [Fact]
+    public void IsNotAdapterForIndividualComponents()
     {
-        [Fact]
-        public void IsNotAdapterForIndividualComponents()
-        {
-            Assert.False(new ViewRegistrationSource().IsAdapterForIndividualComponents);
-        }
+        Assert.False(new ViewRegistrationSource().IsAdapterForIndividualComponents);
+    }
 
-        [Fact]
-        public void RegistrationFoundForViewMasterPageWithModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForViewMasterPageWithModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewMasterPage = lifetimeScope.Resolve<GeneratedViewMasterPageWithModel>();
-            Assert.NotNull(viewMasterPage);
-            Assert.NotNull(viewMasterPage.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewMasterPage = lifetimeScope.Resolve<GeneratedViewMasterPageWithModel>();
+        Assert.NotNull(viewMasterPage);
+        Assert.NotNull(viewMasterPage.Dependency);
+    }
 
-        [Fact]
-        public void RegistrationFoundForViewMasterPageWithoutModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForViewMasterPageWithoutModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewMasterPage = lifetimeScope.Resolve<GeneratedViewMasterPage>();
-            Assert.NotNull(viewMasterPage);
-            Assert.NotNull(viewMasterPage.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewMasterPage = lifetimeScope.Resolve<GeneratedViewMasterPage>();
+        Assert.NotNull(viewMasterPage);
+        Assert.NotNull(viewMasterPage.Dependency);
+    }
 
-        [Fact]
-        public void RegistrationFoundForViewPageWithModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForViewPageWithModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewPage = lifetimeScope.Resolve<GeneratedViewPageWithModel>();
-            Assert.NotNull(viewPage);
-            Assert.NotNull(viewPage.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewPage = lifetimeScope.Resolve<GeneratedViewPageWithModel>();
+        Assert.NotNull(viewPage);
+        Assert.NotNull(viewPage.Dependency);
+    }
 
-        [Fact]
-        public void RegistrationFoundForViewPageWithoutModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForViewPageWithoutModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewPage = lifetimeScope.Resolve<GeneratedViewPage>();
-            Assert.NotNull(viewPage);
-            Assert.NotNull(viewPage.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewPage = lifetimeScope.Resolve<GeneratedViewPage>();
+        Assert.NotNull(viewPage);
+        Assert.NotNull(viewPage.Dependency);
+    }
 
-        [Fact]
-        public void RegistrationFoundForViewUserControlWithModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForViewUserControlWithModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewUserControl = lifetimeScope.Resolve<GeneratedViewUserControlWithModel>();
-            Assert.NotNull(viewUserControl);
-            Assert.NotNull(viewUserControl.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewUserControl = lifetimeScope.Resolve<GeneratedViewUserControlWithModel>();
+        Assert.NotNull(viewUserControl);
+        Assert.NotNull(viewUserControl.Dependency);
+    }
 
-        [Fact]
-        public void RegistrationFoundForViewUserControlWithoutModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForViewUserControlWithoutModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewUserControl = lifetimeScope.Resolve<GeneratedViewUserControl>();
-            Assert.NotNull(viewUserControl);
-            Assert.NotNull(viewUserControl.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewUserControl = lifetimeScope.Resolve<GeneratedViewUserControl>();
+        Assert.NotNull(viewUserControl);
+        Assert.NotNull(viewUserControl.Dependency);
+    }
 
-        [Fact]
-        public void RegistrationFoundForWebViewPageWithModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForWebViewPageWithModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var webViewPage = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
-            Assert.NotNull(webViewPage);
-            Assert.NotNull(webViewPage.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var webViewPage = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
+        Assert.NotNull(webViewPage);
+        Assert.NotNull(webViewPage.Dependency);
+    }
 
-        [Fact]
-        public void RegistrationFoundForWebViewPageWithoutModel()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void RegistrationFoundForWebViewPageWithoutModel()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var webViewPage = lifetimeScope.Resolve<GeneratedWebViewPage>();
-            Assert.NotNull(webViewPage);
-            Assert.NotNull(webViewPage.Dependency);
-        }
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var webViewPage = lifetimeScope.Resolve<GeneratedWebViewPage>();
+        Assert.NotNull(webViewPage);
+        Assert.NotNull(webViewPage.Dependency);
+    }
 
-        [Fact]
-        public void ViewCanHaveInstancePerHttpRequestDependency()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf().InstancePerRequest();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void ViewCanHaveInstancePerHttpRequestDependency()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf().InstancePerRequest();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewPage1 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
-            var viewPage2 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewPage1 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
+        var viewPage2 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
 
-            Assert.Same(viewPage2.Dependency, viewPage1.Dependency);
-        }
+        Assert.Same(viewPage2.Dependency, viewPage1.Dependency);
+    }
 
-        [Fact]
-        public void ViewRegistrationIsInstancePerDependency()
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<Dependency>().AsSelf();
-            builder.RegisterSource(new ViewRegistrationSource());
+    [Fact]
+    public void ViewRegistrationIsInstancePerDependency()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency>().AsSelf();
+        builder.RegisterSource(new ViewRegistrationSource());
 
-            var container = builder.Build();
-            using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
-            var viewPage1 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
-            var viewPage2 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
+        var container = builder.Build();
+        using var lifetimeScope = container.BeginLifetimeScope(MatchingScopeLifetimeTags.RequestLifetimeScopeTag);
+        var viewPage1 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
+        var viewPage2 = lifetimeScope.Resolve<GeneratedWebViewPageWithModel>();
 
-            Assert.NotSame(viewPage2, viewPage1);
-        }
+        Assert.NotSame(viewPage2, viewPage1);
     }
 }


### PR DESCRIPTION
## Summary

- Standardize `.pre-commit-config.yaml`, `.editorconfig`, `build/stylecop.json`, `build/Source.ruleset`, `build/Test.ruleset` to match Autofac core
- Update `default.proj` Package target to pack individual projects
- Apply `dotnet format` code formatting
- Fix SA1201/SA1204 member ordering in 4 files
- Fix SA1616/SA1618 missing XML documentation
- Fix SA1404 SuppressMessage justifications

## Test plan

- [ ] CI build passes
- [ ] All tests pass
- [ ] `pre-commit run --all-files` passes