### PR TITLE
Skip filter evaluation when the controller instance is null (#24)

### DIFF
--- a/src/Autofac.Integration.Mvc/AutofacFilterProvider.cs
+++ b/src/Autofac.Integration.Mvc/AutofacFilterProvider.cs
@@ -94,7 +94,7 @@ public class AutofacFilterProvider : FilterAttributeFilterProvider
         var filters = base.GetFilters(controllerContext, actionDescriptor).ToList();
         var lifetimeScope = AutofacDependencyResolver.Current.RequestLifetimeScope;
 
-        if (lifetimeScope != null)
+        if (lifetimeScope != null && controllerContext.Controller != null)
         {
             foreach (var filter in filters)
             {

--- a/test/Autofac.Integration.Mvc.Test/AutofacFilterProviderFixture.cs
+++ b/test/Autofac.Integration.Mvc.Test/AutofacFilterProviderFixture.cs
@@ -48,6 +48,22 @@ public class AutofacFilterProviderFixture : IClassFixture<DependencyResolverRepl
     }
 
     [Fact]
+    public void NullControllerInstanceIsSkipped()
+    {
+        // Issue #24: when the controller instance is null, the provider should
+        // skip filter evaluation rather than throwing a NullReferenceException,
+        // matching the behavior of the base FilterAttributeFilterProvider.
+        var builder = new ContainerBuilder();
+        var container = builder.Build();
+        SetupMockLifetimeScopeProvider(container);
+        var provider = new AutofacFilterProvider();
+        var controllerContext = new ControllerContext { Controller = null };
+
+        var filters = provider.GetFilters(controllerContext, this._reflectedActionDescriptor).ToList();
+        Assert.Empty(filters);
+    }
+
+    [Fact]
     public void FilterRegistrationsWithoutMetadataIgnored()
     {
         var builder = new ContainerBuilder();


### PR DESCRIPTION
Fixes #24.

## Problem

`AutofacFilterProvider.GetFilters()` threw a `NullReferenceException` when `ControllerContext.Controller` was `null`. It unconditionally called `controllerContext.Controller.GetType()` to build the filter context used for controller- and action-scoped filter resolution.

The base `System.Web.Mvc.FilterAttributeFilterProvider` guards against a null controller and skips filter evaluation in that case, so the derived provider should behave the same way rather than throwing.

## Fix

Guard the controller-scoped resolution block on `controllerContext.Controller != null`. When the controller is null, the provider now returns without attempting type-based filter resolution, matching the base provider's behavior.

## Tests

Added `NullControllerInstanceIsSkipped`, which invokes the provider with a null `Controller` and asserts no filters are returned. Verified the test reproduces the original `NullReferenceException` when the fix is reverted, and passes with it in place.

Full suite: 194 passed, 0 failed (Release config, warnings-as-errors).